### PR TITLE
Expose number utility functions

### DIFF
--- a/lib/web3dart.dart
+++ b/lib/web3dart.dart
@@ -6,5 +6,6 @@ library web3dart;
 export "package:web3dart/src/contracts/abi.dart";
 export "package:web3dart/src/transaction.dart";
 export "package:web3dart/src/utils/amounts.dart";
+export "package:web3dart/src/utils/numbers.dart";
 export "package:web3dart/src/utils/credentials.dart";
 export "package:web3dart/src/web3client.dart";

--- a/web3dart.iml
+++ b/web3dart.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>


### PR DESCRIPTION
The idea is to make the utility functions used internally available to the users to facilitate number manipulations between Hex, BigInt, Bytes format, etc.

Instead of rewriting these already existing functions or load another external library, the existing functions are re-used on the user side.