### PR TITLE
Skip events when parsing the ABI from JSON

### DIFF
--- a/lib/src/contracts/abi.dart
+++ b/lib/src/contracts/abi.dart
@@ -147,17 +147,13 @@ class ContractABI {
 
 		for (var element in data) {
 
-			// ignore non-functions
-			if (element["type"] != 'function') {
+			var type = element["type"];
+			if (type == "event")
 				continue;
-			}
 
 			String name = element["name"];
 			var mutability = _parseMutability(element["stateMutability"]);
 
-			var type = element["type"];
-			if (type == "event")
-        continue;
 			var tp = _parseType(type);
 
 			var inputs = parseParameters(element["inputs"]);

--- a/lib/src/contracts/abi.dart
+++ b/lib/src/contracts/abi.dart
@@ -28,7 +28,7 @@ class DeployedContract {
 
   /// Creates a new contract instance in the libary based on the given abi at
   /// the specified [address]. The contract needs to be deployed on the Ethereum
-  /// net the [client] is connected to. The [auth] parameter controlls the 
+  /// net the [client] is connected to. The [auth] parameter controlls the
   /// address used to send transactions or calls.
 	DeployedContract(this.abi, this.address, this.client, this.auth);
 
@@ -83,7 +83,7 @@ class ContractABI {
 	}
 
 	static List<FunctionParameter> parseParameters(List<dynamic> data) {
-		if (data == null || data.isEmpty) 
+		if (data == null || data.isEmpty)
       return [];
 
 		var elements = <FunctionParameter>[];
@@ -129,7 +129,7 @@ class ContractABI {
 			var length = int.parse(type.substring(5));
 			return new StaticLengthBytes(length);
 		}
-		
+
 		//Names that only have a single name
 		switch (type) {
 			case "string": return new StringType();
@@ -147,11 +147,17 @@ class ContractABI {
 		var functions = <ContractFunction>[];
 
 		for (var element in data) {
+
+		  // ignore non-functions
+		  if (element["type"] != 'function') {
+				continue;
+			}
+
 			String name = element["name"];
 			var mutability = _parseMutability(element["stateMutability"]);
 
 			var type = element["type"];
-			if (type == "event") 
+			if (type == "event")
         continue;
 			var tp = _parseType(type);
 
@@ -232,6 +238,7 @@ class ContractFunction {
 	///
 	/// Other types are not supported at the moment.
 	String encodeCall(List<dynamic> params) {
+
 		if (params.length != parameters.length)
 			throw new ArgumentError.value(params.length, "params", "Must match function parameters");
 
@@ -249,6 +256,7 @@ class ContractFunction {
 		var dynamicEncodings = [];
 
 		for (var i = 0; i < parameters.length; i++) {
+
 			var parameter = parameters[i];
 			var value = params[i];
 
@@ -299,7 +307,7 @@ class ContractFunction {
 	/// The type of what this function returns is thus dependent from what it
 	/// [outputs] are. For the conversions between dart types and solidity types,
 	/// see the documentation for [encodeCall].
-	dynamic decodeReturnValues(String data) {
+	List<dynamic> decodeReturnValues(String data) {
 		var modifiedData = numbers.strip0x(data);
 
 		var decoded = <dynamic>[];

--- a/lib/src/contracts/abi.dart
+++ b/lib/src/contracts/abi.dart
@@ -149,7 +149,7 @@ class ContractABI {
 		for (var element in data) {
 
 		  // ignore non-functions
-		  if (element["type"] != 'function') {
+			if (element["type"] != 'function') {
 				continue;
 			}
 

--- a/lib/src/contracts/abi.dart
+++ b/lib/src/contracts/abi.dart
@@ -256,7 +256,6 @@ class ContractFunction {
 		var dynamicEncodings = [];
 
 		for (var i = 0; i < parameters.length; i++) {
-
 			var parameter = parameters[i];
 			var value = params[i];
 

--- a/lib/src/contracts/abi.dart
+++ b/lib/src/contracts/abi.dart
@@ -129,7 +129,6 @@ class ContractABI {
 			var length = int.parse(type.substring(5));
 			return new StaticLengthBytes(length);
 		}
-
 		//Names that only have a single name
 		switch (type) {
 			case "string": return new StringType();
@@ -148,7 +147,7 @@ class ContractABI {
 
 		for (var element in data) {
 
-		  // ignore non-functions
+			// ignore non-functions
 			if (element["type"] != 'function') {
 				continue;
 			}
@@ -238,7 +237,6 @@ class ContractFunction {
 	///
 	/// Other types are not supported at the moment.
 	String encodeCall(List<dynamic> params) {
-
 		if (params.length != parameters.length)
 			throw new ArgumentError.value(params.length, "params", "Must match function parameters");
 


### PR DESCRIPTION
This PR stops the ABI parsing from looking at anything but functions, avoiding some erroneous errors.

Bonus: typings + trailing whitespace fixes

Fixes #13 