### PR TITLE
Add getTransactionByHash method

### DIFF
--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -161,8 +161,8 @@ class TransactionInformation {
 	TransactionInformation.fromMap(Map<String, dynamic> map) :
 			blockHash = map['blockHash'],
 			blockNumber = map['blockNumber'] != null ?
-			BlockNum.exact(int.parse(map['blockNumber'])) :
-			BlockNum.pending(),
+				BlockNum.exact(int.parse(map['blockNumber'])) :
+				BlockNum.pending(),
 			from = EthereumAddress(map['from']),
 			gas = int.parse(map['gas']),
 			gasPrice = EtherAmount.inWei(BigInt.parse(map['gasPrice'])),

--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:web3dart/conversions.dart';
 import 'package:web3dart/src/io/rawtransaction.dart';
 import "package:web3dart/src/utils/numbers.dart" as numbers;
 import 'package:web3dart/web3dart.dart';
@@ -126,4 +127,41 @@ class FinalizedTransaction {
 			return client.call(base._keys, raw, _function, chainId: chainId);
 		});
 	}
+}
+
+class TransactionInformation {
+	String blockHash;
+	int blockNumber;
+	EthereumAddress from;
+	int gas;
+	int gasPrice;
+	String hash;
+	List<int> input;
+	int nonce;
+	EthereumAddress to;
+	int transactionIndex;
+	EtherAmount value;
+	int v;
+	List<int> r;
+	List<int> s;
+
+	TransactionInformation.fromMap(Map<String, dynamic> map) :
+			blockHash = map['blockHash'],
+			blockNumber = map['blockNumber'] != null ?
+				int.parse(map['blockNumber']) :
+				null,
+			from = EthereumAddress(map['from']),
+			gas = int.parse(map['gas']),
+			gasPrice = int.parse(map['gasPrice']),
+			hash = map['hash'],
+			input = hexToBytes(map['input']),
+			nonce = int.parse(map['nonce']),
+			to = map['to'] != null ? EthereumAddress(map['to']) : null,
+			transactionIndex = map['transactionIndex'] != null ?
+				int.parse(map['transactionIndex']) :
+				null,
+			value = EtherAmount.inWei(BigInt.parse(map['value'])),
+			v = int.parse(map['v']),
+			r = hexToBytes(map['r']),
+			s = hexToBytes(map['s']);
 }

--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -130,29 +130,42 @@ class FinalizedTransaction {
 }
 
 class TransactionInformation {
-	String blockHash;
-	int blockNumber;
-	EthereumAddress from;
-	int gas;
-	int gasPrice;
-	String hash;
-	List<int> input;
-	int nonce;
-	EthereumAddress to;
+
+	/// The hash of the block containing this transaction. If this transaction has
+	/// not been mined yet and is thus in no block, it will be `null`
+	final String blockHash;
+
+	/// [BlockNum] of the block containing this transaction. `null` when it's
+	/// pending
+	final BlockNum blockNumber;
+
+	final EthereumAddress from;
+	final int gas;
+	final EtherAmount gasPrice;
+	final String hash;
+	final List<int> input;
+	final int nonce;
+
+	/// Address of the receiver. `null` when its a contract creation transaction
+	final EthereumAddress to;
+
+	/// Integer of the transaction's index position in the block. `null` when it's
+	/// pending.
 	int transactionIndex;
-	EtherAmount value;
-	int v;
-	List<int> r;
-	List<int> s;
+
+	final EtherAmount value;
+	final int v;
+	final List<int> r;
+	final List<int> s;
 
 	TransactionInformation.fromMap(Map<String, dynamic> map) :
 			blockHash = map['blockHash'],
 			blockNumber = map['blockNumber'] != null ?
-				int.parse(map['blockNumber']) :
-				null,
+			BlockNum.exact(int.parse(map['blockNumber'])) :
+			BlockNum.pending(),
 			from = EthereumAddress(map['from']),
 			gas = int.parse(map['gas']),
-			gasPrice = int.parse(map['gasPrice']),
+			gasPrice = EtherAmount.inWei(BigInt.parse(map['gasPrice'])),
 			hash = map['hash'],
 			input = hexToBytes(map['input']),
 			nonce = int.parse(map['nonce']),

--- a/lib/src/web3client.dart
+++ b/lib/src/web3client.dart
@@ -156,6 +156,13 @@ class Web3Client {
 				.then((s) => numbers.hexToInt(s)).then((d) => d.toInt());
 	}
 
+	/// Returns the information about a transaction requested by transaction hash
+	/// [transactionHash].
+	Future<TransactionInformation> getTransactionByHash(String transactionHash) {
+		return _makeRPCCall("eth_getTransactionByHash", [transactionHash])
+				.then((s) => TransactionInformation.fromMap(s));
+	}
+
 	/// Gets the code of a contract at the specified [address]
 	///
 	/// This function allows specifying a custom block mined in the past to get


### PR DESCRIPTION
Added `getTransactionByHash` RPC method.

Disclaimer: I'm not used to working with tab indents or even general dart formatting standards, but I think this formatting follows the rest of the repo.