### PR TITLE
transaction_signer will fail if to not set

### DIFF
--- a/lib/src/core/transaction_signer.dart
+++ b/lib/src/core/transaction_signer.dart
@@ -99,7 +99,7 @@ List<dynamic> _encodeToRlp(Transaction transaction, MsgSignature signature) {
   if (transaction.to != null) {
     list.add(transaction.to.addressBytes);
   } else {
-    list.add([]);
+    list.add('');
   }
 
   list..add(transaction.value.getInWei)..add(transaction.data);


### PR DESCRIPTION
When Transaction's to is not set, TransactionSigner will fail due to a bug in _encodeToRpl(). 

I changed default value to empty string instead of empty list and it works now.