### PR TITLE
Add include0x for data in the eth_estimateGas call

### DIFF
--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -331,7 +331,7 @@ class Web3Client {
           if (amountOfGas != null) 'gas': '0x${amountOfGas.toRadixString(16)}',
           if (gasPrice != null)
             'gasPrice': '0x${amountOfGas.toRadixString(16)}',
-          if (data != null) 'data': bytesToHex(data),
+          if (data != null) 'data': bytesToHex(data,include0x: true),
         },
       ],
     );

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -331,7 +331,7 @@ class Web3Client {
           if (amountOfGas != null) 'gas': '0x${amountOfGas.toRadixString(16)}',
           if (gasPrice != null)
             'gasPrice': '0x${amountOfGas.toRadixString(16)}',
-          if (data != null) 'data': bytesToHex(data,include0x: true),
+          if (data != null) 'data': bytesToHex(data, include0x: true),
         },
       ],
     );


### PR DESCRIPTION
Add `include0x` for data in the eth_estimateGas call.

Without it the call will return 
`Unhandled Exception: RPCError: got code -32602 with msg "invalid argument 0: json: cannot unmarshal hex string without 0x prefix into Go struct field CallArgs.data of type hexutil.Bytes"`
 on infura with Transaction.data that has been generated by Transaction.callContract.