### PR TITLE
Adding support for signature verification and public key recovery

### DIFF
--- a/lib/src/credentials/credentials.dart
+++ b/lib/src/credentials/credentials.dart
@@ -23,8 +23,8 @@ abstract class Credentials {
   Future<Uint8List> sign(Uint8List payload, {int chainId}) async {
     final signature = await signToSignature(payload, chainId: chainId);
 
-    final r = _padTo32(intToBytes(signature.r));
-    final s = _padTo32(intToBytes(signature.s));
+    final r = padUint8ListTo32(intToBytes(signature.r));
+    final s = padUint8ListTo32(intToBytes(signature.s));
     final v = intToBytes(BigInt.from(signature.v));
 
     // https://github.com/ethereumjs/ethereumjs-util/blob/8ffe697fafb33cefc7b7ec01c11e3a7da787fe0e/src/signature.ts#L63
@@ -46,14 +46,6 @@ abstract class Credentials {
     final concat = uint8ListFromList(prefixBytes + payload);
 
     return sign(concat, chainId: chainId);
-  }
-
-  Uint8List _padTo32(Uint8List data) {
-    assert(data.length <= 32);
-    if (data.length == 32) return data;
-
-    // todo there must be a faster way to do this?
-    return Uint8List(32)..setRange(32 - data.length, 32, data);
   }
 }
 

--- a/lib/src/crypto/secp256k1.dart
+++ b/lib/src/crypto/secp256k1.dart
@@ -97,6 +97,7 @@ MsgSignature sign(Uint8List messageHash, Uint8List privateKey) {
 
 /// Given an arbitrary message hash and an Ethereum message signature encoded in bytes, returns
 /// the public key that was used to sign it.
+/// https://github.com/web3j/web3j/blob/c0b7b9c2769a466215d416696021aa75127c2ff1/crypto/src/main/java/org/web3j/crypto/Sign.java#L241
 Uint8List ecRecover(Uint8List messageHash, MsgSignature signatureData) {
   assert(signatureData.r != null);
   assert(signatureData.s != null);
@@ -123,7 +124,7 @@ Uint8List ecRecover(Uint8List messageHash, MsgSignature signatureData) {
 }
 
 /// Given an arbitrary message hash, an Ethereum message signature encoded in bytes and
-/// a public key encoded in bytes, confirms whether that public key was used to sign 
+/// a public key encoded in bytes, confirms whether that public key was used to sign
 /// the message or not.
 bool isValidSignature(
     Uint8List messageHash, MsgSignature signatureData, Uint8List publicKey) {

--- a/lib/src/crypto/secp256k1.dart
+++ b/lib/src/crypto/secp256k1.dart
@@ -95,6 +95,42 @@ MsgSignature sign(Uint8List messageHash, Uint8List privateKey) {
   return MsgSignature(sig.r, sig.s, recId + 27);
 }
 
+/// Given an arbitrary message hash and an Ethereum message signature encoded in bytes, returns
+/// the public key that was used to sign it.
+Uint8List ecRecover(Uint8List messageHash, MsgSignature signatureData) {
+  assert(signatureData.r != null);
+  assert(signatureData.s != null);
+  final r = padUint8ListTo32(intToBytes(signatureData.r));
+  final s = padUint8ListTo32(intToBytes(signatureData.s));
+  assert(r.length == 32);
+  assert(s.length == 32);
+
+  final header = signatureData.v & 0xFF;
+  // The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
+  //                  0x1D = second key with even y, 0x1E = second key with odd y
+  if (header < 27 || header > 34) {
+    throw Exception('Header byte out of range: $header');
+  }
+
+  final sig = ECSignature(signatureData.r, signatureData.s);
+
+  final recId = header - 27;
+  final pubKey = _recoverFromSignature(recId, sig, messageHash, _params);
+  if (pubKey == null) {
+    throw Exception('Could not recover public key from signature');
+  }
+  return intToBytes(pubKey);
+}
+
+/// Given an arbitrary message hash, an Ethereum message signature encoded in bytes and
+/// a public key encoded in bytes, confirms whether that public key was used to sign 
+/// the message or not.
+bool isValidSignature(
+    Uint8List messageHash, MsgSignature signatureData, Uint8List publicKey) {
+  final recoveredPublicKey = ecRecover(messageHash, signatureData);
+  return bytesToHex(publicKey) == bytesToHex(recoveredPublicKey);
+}
+
 BigInt _recoverFromSignature(
     int recId, ECSignature sig, Uint8List msg, ECDomainParameters params) {
   final n = params.n;

--- a/lib/src/utils/typed_data.dart
+++ b/lib/src/utils/typed_data.dart
@@ -5,3 +5,11 @@ Uint8List uint8ListFromList(List<int> data) {
 
   return Uint8List.fromList(data);
 }
+
+Uint8List padUint8ListTo32(Uint8List data) {
+  assert(data.length <= 32);
+  if (data.length == 32) return data;
+
+  // todo there must be a faster way to do this?
+  return Uint8List(32)..setRange(32 - data.length, 32, data);
+}

--- a/test/crypto/secp256k1_test.dart
+++ b/test/crypto/secp256k1_test.dart
@@ -108,15 +108,18 @@ void main() {
         final signature = sign(messageHash, hexToBytes(privateKey));
 
         expect(
-            isValidSignature(messageHash, signature, originalPublicKey), true,
-            reason: 'The signature should be valid');
+          isValidSignature(messageHash, signature, originalPublicKey),
+          isTrue,
+          reason: 'The signature should be valid',
+        );
 
         for (final invalidPublicKey in invalidPublicKeys) {
           expect(
-              isValidSignature(
-                  messageHash, signature, hexToBytes(invalidPublicKey)),
-              false,
-              reason: 'The signature should be invalid');
+            isValidSignature(
+                messageHash, signature, hexToBytes(invalidPublicKey)),
+            isFalse,
+            reason: 'The signature should be invalid',
+          );
         }
       }
     }

--- a/test/crypto/secp256k1_test.dart
+++ b/test/crypto/secp256k1_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:typed_data';
 import 'package:test/test.dart';
 import 'package:web3dart/crypto.dart';
 
@@ -45,5 +47,78 @@ void main() {
         hexToInt(
             '129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'));
     expect(sig.v, 27);
+  });
+
+  test('signatures recover the public key of the signer', () {
+    final messages = [
+      'Hello world',
+      'UTF8 chars ©âèíöu ∂øµ€',
+      '🚀✨🌎',
+      DateTime.now().toString()
+    ];
+    final privateKeys = [
+      '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1',
+      'a69ab6a98f9c6a98b9a6b8e9b6a8e69c6ea96b5050eb77a17e3ba685805aeb88',
+      'ca7eb9798e79c8799ea79aec7be98a7b9a7c98ae7b98061a53be764a85b8e785',
+      '192b519765c9589a6b8c9a486ab938cba9638ab876056237649264b9cb96d88f',
+      'b6a8f6a96931ad89d3a98e69ad6b98794673615b74675d7b5a674ba82b648a6d'
+    ];
+
+    for (final message in messages) {
+      final messageHash = keccak256(Uint8List.fromList(utf8.encode(message)));
+
+      for (final privateKey in privateKeys) {
+        final publicKey = privateKeyBytesToPublic(hexToBytes(privateKey));
+        final signature = sign(messageHash, hexToBytes(privateKey));
+
+        final recoveredPublicKey = ecRecover(messageHash, signature);
+        expect(bytesToHex(publicKey), bytesToHex(recoveredPublicKey));
+      }
+    }
+  });
+
+  test('signature validity can be properly verified', () {
+    final messages = [
+      'Hello world',
+      'UTF8 chars ©âèíöu ∂øµ€',
+      '🚀✨🌎',
+      DateTime.now().toString()
+    ];
+    final privateKeys = [
+      '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1',
+      'a69ab6a98f9c6a98b9a6b8e9b6a8e69c6ea96b5050eb77a17e3ba685805aeb88',
+      'ca7eb9798e79c8799ea79aec7be98a7b9a7c98ae7b98061a53be764a85b8e785',
+      '192b519765c9589a6b8c9a486ab938cba9638ab876056237649264b9cb96d88f',
+      'b6a8f6a96931ad89d3a98e69ad6b98794673615b74675d7b5a674ba82b648a6d'
+    ];
+    final invalidPublicKeys = [
+      '1cb507195305b0c70da9f0a60f06ae8d605a80f0abc05a08df50a50f8e085da0f5a8f0e508adf510f0b1827538649a7bc79a47d49ae64b06ac60a96195231241',
+      '0c7a0980f1803b09c88a4c78a4186d48a76739a34a685075a084179a46c96a5d8705a0845a365254a34679a67413567a426ca1436e5758f96a57a5f78a4321a7',
+      'c6b6a1c431b4a374d38a549ef7a659e7505fa07e574648a63537a6d546f85a48e73765a37a4d64c976a449a64e853a75684e9a75d964a8563e684a66ea058494',
+      'ba969f86a968e76ba9769f6a98e6f98a6d9876f9a87b9f876eb987ac6b98a6d98f5a97645865e37a4264d3a63865187687917619876bc9a876d986fa9b861972',
+      'a9173ba7961b6fdb37d618036b0abd8a7e6b9a7f6b98e769a861982639451982739ba9afd9e8a487146728354198a9fda9e481239145972364597a9da5976129',
+    ];
+
+    for (final message in messages) {
+      final messageHash = keccak256(Uint8List.fromList(utf8.encode(message)));
+
+      for (final privateKey in privateKeys) {
+        final originalPublicKey =
+            privateKeyBytesToPublic(hexToBytes(privateKey));
+        final signature = sign(messageHash, hexToBytes(privateKey));
+
+        expect(
+            isValidSignature(messageHash, signature, originalPublicKey), true,
+            reason: 'The signature should be valid');
+
+        for (final invalidPublicKey in invalidPublicKeys) {
+          expect(
+              isValidSignature(
+                  messageHash, signature, hexToBytes(invalidPublicKey)),
+              false,
+              reason: 'The signature should be invalid');
+        }
+      }
+    }
   });
 }


### PR DESCRIPTION
Please, review the changes of current Pull Request.

What it does:
- Providing `ecRecover()` and `isValidSignature()`
- Adding unit tests for `ecRecover()` and `isValidSignature()`
- Making `_padTo32()` reusable for other components, so that it can be reused when converting the R/S values of a signature to a `Uint8List`
- `pub run test` runs clean

Please, let me know if you'd like an example added to the Readme or in the `example` folder.

Thank you