### PR TITLE
hexToBytes: add odd length support

### DIFF
--- a/lib/src/crypto/formatting.dart
+++ b/lib/src/crypto/formatting.dart
@@ -38,7 +38,9 @@ String bytesToHex(List<int> bytes,
 /// Converts the hexadecimal string, which can be prefixed with 0x, to a byte
 /// sequence.
 Uint8List hexToBytes(String hexStr) {
-  final bytes = hex.decode(strip0x(hexStr));
+  hexStr = strip0x(hexStr);
+  if (hexStr.length % 2 != 0) hexStr = '0$hexStr';
+  final bytes = hex.decode(hexStr);
   if (bytes is Uint8List) return bytes;
 
   return Uint8List.fromList(bytes);

--- a/test/crypto/formatting_test.dart
+++ b/test/crypto/formatting_test.dart
@@ -12,4 +12,12 @@ void main() {
     expect(hexToDartInt('0xff'), 0xff);
     expect(hexToDartInt('abcdef'), 0xabcdef);
   });
+
+  test('hexToBytes handles odd length', () {
+    expect(
+        hexToBytes(
+            '0xcf1daa12796907b13c6e104ee7185eb8b1e34db92b55a4655c147ff2fe5563c'),
+        hexToBytes(
+            '0x0cf1daa12796907b13c6e104ee7185eb8b1e34db92b55a4655c147ff2fe5563c'));
+  });
 }


### PR DESCRIPTION
This PR adds support for odd length hex strings to `hexToBytes`.

I discovered odd length hex strings in the wild. For example, the tx below has an 'r' value with a leading 0, and the linkpool rpc api returns it at an odd length, which errors out in `hexToBytes`.
 https://ropsten.etherscan.io/tx/0x36f3fde9094e1e2ff1181714d48105a776f16b663cc9e03502f08ef85748c5b5

```sh
> curl -X POST -H 'Content-Type:application/json' --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x36f3fde9094e1e2ff1181714d48105a776f16b663cc9e03502f08ef85748c5b5"],"id":12}' https://ropsten-rpc.linkpool.io

{"jsonrpc":"2.0","result":{"blockHash":"0x169d8c9a46e879d36fab85962c392c4f109ffdd5d652350daeee84c7e4f81e15","blockNumber":"0x74c4c2","chainId":"0x3","condition":null,"creates":null,"from":"0x32158b701e8631225d48a1ad58d5a27393b3e318","gas":"0x15f90","gasPrice":"0x3b9aca00","hash":"0x36f3fde9094e1e2ff1181714d48105a776f16b663cc9e03502f08ef85748c5b5","input":"0x40c826710000000000000000000000000000000000000000000000056bc75e2d63100000","nonce":"0x62","publicKey":"0x41fb8d06ed2a50f0a0e0539408f4115799be08ad07669ae611239de0d127f3169e3cca2a0b956de810d15ed2c3b78bde24da3a911c6b12bdae6d99df0399d5a0","r":"0xcf1daa12796907b13c6e104ee7185eb8b1e34db92b55a4655c147ff2fe5563c","raw":"0xf88862843b9aca0083015f9094976d3cfb1d511b3133b6e373f20b2e143833fc2080a440c826710000000000000000000000000000000000000000000000056bc75e2d6310000029a00cf1daa12796907b13c6e104ee7185eb8b1e34db92b55a4655c147ff2fe5563ca05fe9ffba6f09c7caf37d3821961fd2e722082873e39910284f78efc9bf2abb48","s":"0x5fe9ffba6f09c7caf37d3821961fd2e722082873e39910284f78efc9bf2abb48","standardV":"0x0","to":"0x976d3cfb1d511b3133b6e373f20b2e143833fc20","transactionIndex":"0x19","v":"0x29","value":"0x0"},"id":12}
```