### PR TITLE
receipt: tolerate null 'from' and 'gasUsed'

### DIFF
--- a/lib/src/core/transaction_information.dart
+++ b/lib/src/core/transaction_information.dart
@@ -116,7 +116,9 @@ class TransactionReceipt {
         blockNumber = map['blockNumber'] != null
             ? BlockNum.exact(int.parse(map['blockNumber'] as String))
             : const BlockNum.pending(),
-        from = EthereumAddress.fromHex(map['from'] as String),
+        from = map['from'] != null
+            ? EthereumAddress.fromHex(map['from'] as String)
+            : null,
         to = map['to'] != null
             ? EthereumAddress.fromHex(map['to'] as String)
             : null,

--- a/lib/src/core/transaction_information.dart
+++ b/lib/src/core/transaction_information.dart
@@ -123,7 +123,8 @@ class TransactionReceipt {
             ? EthereumAddress.fromHex(map['to'] as String)
             : null,
         cumulativeGasUsed = hexToInt(map['cumulativeGasUsed'] as String),
-        gasUsed = hexToInt(map['gasUsed'] as String),
+        gasUsed =
+            map['gasUsed'] != null ? hexToInt(map['gasUsed'] as String) : null,
         contractAddress = map['contractAddress'] != null
             ? EthereumAddress.fromHex(map['contractAddress'] as String)
             : null,


### PR DESCRIPTION
This PR proposes tolerating a null `from` field in a `TransactionReceipt`. The spec suggests it should be set, but ropsten-rpc.linkpool.io is omitting it. Curiously, geth's _client_ does not look for it even though the backend sends it. web3js docs have [examples](https://web3js.readthedocs.io/en/v2.0.0-alpha.1/web3-eth.html#id64) omitting it. :man_shrugging: 

Ropsten linkpool example:
```sh
> curl -X POST -H 'Content-Type:application/json' --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x36f3fde9094e1e2ff1181714d48105a776f16b663cc9e03502f08ef85748c5b5"],"id":12}' https://ropsten-rpc.linkpool.io

{"jsonrpc":"2.0","result":{"blockHash":"0x169d8c9a46e879d36fab85962c392c4f109ffdd5d652350daeee84c7e4f81e15","blockNumber":"0x74c4c2","contractAddress":null,"cumulativeGasUsed":"0x33f3fc","from":null,"gasUsed":null,"logs":[{"address":"0x3279c4d30fe64e4164fa60bcbe0876620925e254","blockHash":null,"blockNumber":null,"data":"0x0000000000000000000000000000000000000000000000056bc75e2d63100000","logIndex":null,"removed":false,"topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x00000000000000000000000032158b701e8631225d48a1ad58d5a27393b3e318","0x000000000000000000000000976d3cfb1d511b3133b6e373f20b2e143833fc20"],"transactionHash":null,"transactionIndex":null,"transactionLogIndex":null,"type":"pending"},{"address":"0x3279c4d30fe64e4164fa60bcbe0876620925e254","blockHash":null,"blockNumber":null,"data":"0x0000000000000000000000000000000000000000000000000000000000000000","logIndex":null,"removed":false,"topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x00000000000000000000000032158b701e8631225d48a1ad58d5a27393b3e318","0x000000000000000000000000976d3cfb1d511b3133b6e373f20b2e143833fc20"],"transactionHash":null,"transactionIndex":null,"transactionLogIndex":null,"type":"pending"},{"address":"0x976d3cfb1d511b3133b6e373f20b2e143833fc20","blockHash":null,"blockNumber":null,"data":"0x0000000000000000000000000000000000000000000000056bc75e2d63100000","logIndex":null,"removed":false,"topics":["0xda2543cfac858777ecd10b22ad9db15a5d6fc0eb2abd01e4dbbb30f012bb168c","0x00000000000000000000000032158b701e8631225d48a1ad58d5a27393b3e318"],"transactionHash":null,"transactionIndex":null,"transactionLogIndex":null,"type":"pending"}],"logsBloom":"0x00000000001000000000400000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000200000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000010000000000000000000000000000000001000000000000000000000000000000000000000020000000000000000000000000200000000000000000000000200000000000000000802800000000000000000010000000000000000000810000000000000000010020000000000000200000080000000000000000000000000000000000000","status":"0x1","to":null,"transactionHash":"0x36f3fde9094e1e2ff1181714d48105a776f16b663cc9e03502f08ef85748c5b5","transactionIndex":"0x19"},"id":12}
```