### PR TITLE
Fix TransactionReceipt

### DIFF
--- a/lib/src/core/transaction_information.dart
+++ b/lib/src/core/transaction_information.dart
@@ -128,5 +128,5 @@ class TransactionReceipt {
         contractAddress = map['contractAddress'] != null
             ? EthereumAddress.fromHex(map['contractAddress'] as String)
             : null,
-        status = hexToDartInt(map['status'] as String) == 1;
+        status = map['status'] != null ? hexToDartInt(map['status'] as String) == 1 : null;
 }

--- a/lib/src/crypto/formatting.dart
+++ b/lib/src/crypto/formatting.dart
@@ -2,6 +2,7 @@ part of 'package:web3dart/crypto.dart';
 
 /// If present, removes the 0x from the start of a hex-string.
 String strip0x(String hex) {
+  if(hex == null) return null;
   if (hex.startsWith('0x')) return hex.substring(2);
   return hex;
 }


### PR DESCRIPTION
https://github.com/simolus3/web3dart/issues/62#issuecomment-610279662

Fixed the error to be able to retrieve TransactionReceipt. 
Not sure why I don't receive status flag with my response. But This wont break anything anyways.
The check for ``null``in ``strip0x``shall be necessary anyways.