### PR TITLE
Update client.dart

### DIFF
--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -278,18 +278,20 @@ class Web3Client {
 
     return sendRawTransaction(signed);
   }
-  
-  /// Send raw transaction.Create and sign transaction using [signTrasaction].
-  /// Then send transaction when needed.
+
+  /// Sends a raw, signed transaction.
+  ///
+  /// To obtain a transaction in a signed form, use [signTransaction].
   ///
   /// Returns a hash of the transaction which, after the transaction has been
   /// included in a mined block, can be used to obtain detailed information
   /// about the transaction.
   Future<String> sendRawTransaction(Uint8List signedTransaction) async {
-    return _makeRPCCall('eth_sendRawTransaction',
-        [bytesToHex(signedTransaction, include0x: true, padToEvenLength: true)]);
+    return _makeRPCCall('eth_sendRawTransaction', [
+      bytesToHex(signedTransaction, include0x: true, padToEvenLength: true)
+    ]);
   }
-  
+
   /// Signs the [transaction] with the credentials [cred]. The transaction will
   /// not be sent.
   ///

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -279,7 +279,18 @@ class Web3Client {
     return _makeRPCCall('eth_sendRawTransaction',
         [bytesToHex(signed, include0x: true, padToEvenLength: true)]);
   }
-
+  
+  /// Send raw transaction.Create and sign transaction using [signTrasaction].
+  /// Then send transaction when needed.
+  ///
+  /// Returns a hash of the transaction which, after the transaction has been
+  /// included in a mined block, can be used to obtain detailed information
+  /// about the transaction.
+  Future<String> sendRawTransaction(Uint8List signedTransaction) async {
+    return _makeRPCCall('eth_sendRawTransaction',
+        [bytesToHex(signed, include0x: true, padToEvenLength: true)]);
+  }
+  
   /// Signs the [transaction] with the credentials [cred]. The transaction will
   /// not be sent.
   ///

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -276,8 +276,7 @@ class Web3Client {
     final signed = await signTransaction(cred, transaction,
         chainId: chainId, fetchChainIdFromNetworkId: fetchChainIdFromNetworkId);
 
-    return _makeRPCCall('eth_sendRawTransaction',
-        [bytesToHex(signed, include0x: true, padToEvenLength: true)]);
+    return sendRawTransaction(signed);
   }
   
   /// Send raw transaction.Create and sign transaction using [signTrasaction].

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -288,7 +288,7 @@ class Web3Client {
   /// about the transaction.
   Future<String> sendRawTransaction(Uint8List signedTransaction) async {
     return _makeRPCCall('eth_sendRawTransaction',
-        [bytesToHex(signed, include0x: true, padToEvenLength: true)]);
+        [bytesToHex(signedTransaction, include0x: true, padToEvenLength: true)]);
   }
   
   /// Signs the [transaction] with the credentials [cred]. The transaction will


### PR DESCRIPTION
Web3Client class have method signTransaction(), but we can`t send raw signed transaction using public API of this lib. 