### PR TITLE
add 'value' param usage in eth_estimageGas call

### DIFF
--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -362,6 +362,7 @@ class Web3Client {
           if (amountOfGas != null) 'gas': '0x${amountOfGas.toRadixString(16)}',
           if (gasPrice != null)
             'gasPrice': '0x${gasPrice.getInWei.toRadixString(16)}',
+          if (value != null) 'value' : '0x${value.toRadixString(16)}',
           if (data != null) 'data': bytesToHex(data, include0x: true),
         },
       ],


### PR DESCRIPTION
you can use parameter 'value' in estimateGas rpc method, but this lib doesnt use this parameter. it required for contract calls with coins transfers. (for example, Binance Smart Chain Cross-Chain transfer uses contract call with coin transfer in case BNB swap).