### PR TITLE
add 'value' param usage in eth_estimageGas call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+## 2.1.1
+
+- Respect the `value` parameter in `estimateGas`
 
 ## 2.1.0
 

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -362,7 +362,7 @@ class Web3Client {
           if (amountOfGas != null) 'gas': '0x${amountOfGas.toRadixString(16)}',
           if (gasPrice != null)
             'gasPrice': '0x${gasPrice.getInWei.toRadixString(16)}',
-          if (value != null) 'value' : '0x${value.toRadixString(16)}',
+          if (value != null) 'value' : '0x${value.getInWei.toRadixString(16)}',
           if (data != null) 'data': bytesToHex(data, include0x: true),
         },
       ],

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -362,6 +362,7 @@ class Web3Client {
           if (amountOfGas != null) 'gas': '0x${amountOfGas.toRadixString(16)}',
           if (gasPrice != null)
             'gasPrice': '0x${gasPrice.getInWei.toRadixString(16)}',
+          if (value != null) 'value' : '0x${value.toRadixString(16)}',
           if (data != null) 'data': bytesToHex(data, include0x: true),
         },
       ],

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -362,7 +362,7 @@ class Web3Client {
           if (amountOfGas != null) 'gas': '0x${amountOfGas.toRadixString(16)}',
           if (gasPrice != null)
             'gasPrice': '0x${gasPrice.getInWei.toRadixString(16)}',
-          if (value != null) 'value' : '0x${value.getInWei.toRadixString(16)}',
+          if (value != null) 'value': '0x${value.getInWei.toRadixString(16)}',
           if (data != null) 'data': bytesToHex(data, include0x: true),
         },
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web3dart
 description: Dart library to connect to Ethereum clients. Send transactions and interact with smart contracts!
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/simolus3/web3dart
 
 environment: 

--- a/test/builder/data.dart
+++ b/test/builder/data.dart
@@ -1,5 +1,5 @@
 const testCases = <String, String>{
-'''
+  '''
 [
     {
       "inputs": [
@@ -35,8 +35,7 @@ const testCases = <String, String>{
       "stateMutability": "pure",
       "type": "function"
     }
-]''':
-'''
+]''': '''
 // Generated code, do not modify. Run `build_runner build` to re-generate!
 // @dart=2.12
 import 'package:web3dart/web3dart.dart' as _i1;
@@ -76,7 +75,7 @@ class Retrieve3 {
   final bool var3;
 }
 ''',
-'''
+  '''
 [
     {
       "inputs": [],
@@ -127,8 +126,7 @@ class Retrieve3 {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-]''':
-'''
+]''': '''
 // Generated code, do not modify. Run `build_runner build` to re-generate!
 // @dart=2.12
 import 'package:web3dart/web3dart.dart' as _i1;
@@ -184,7 +182,7 @@ class GiveMeHello {
   final BigInt num2;
 }
 ''',
-'''
+  '''
 [
     {
         "inputs": [],
@@ -199,8 +197,7 @@ class GiveMeHello {
         "stateMutability": "view",
         "type": "function"
     }
-]''':
-'''
+]''': '''
 // Generated code, do not modify. Run `build_runner build` to re-generate!
 // @dart=2.12
 import 'package:web3dart/web3dart.dart' as _i1;


### PR DESCRIPTION
you can use parameter 'value' in estimateGas rpc method, but this lib doesnt use this parameter. it required for contract calls with coins transfers. (for example, Binance Smart Chain Cross-Chain transfer uses contract call with coin transfer in case BNB swap).