### PR TITLE
Links in readme should be secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The library won't send signed transactions to miners itself. Instead,
 it relies on an RPC client to do that. You can use a public RPC API like
 [infura](https://infura.io/), setup your own using [geth](https://github.com/ethereum/go-ethereum/wiki/geth)
 or, if you just want to test things out, use a private testnet with
-[truffle](http://truffleframework.com/) and [ganache](http://truffleframework.com/ganache/). All these options will give you
+[truffle](https://www.trufflesuite.com/) and [ganache](https://www.trufflesuite.com/ganache). All these options will give you
 an RPC endpoint to which the library can connect.
 
 ```dart


### PR DESCRIPTION
#follow dart file convention 👍 
As per dart.pub Links in `README.md` should be secure. 2 links are insecure. It was giving 0/5 score. Truffle and Ganache website links also updated.
<img width="932" alt="Screenshot 2021-06-11 at 11 20 10 PM" src="https://user-images.githubusercontent.com/84236781/121729521-35f18980-cb0c-11eb-8591-cde03e06f1b3.png">
