### PR TITLE
Add optional additional headers

### DIFF
--- a/lib/json_rpc.dart
+++ b/lib/json_rpc.dart
@@ -14,7 +14,11 @@ abstract class RpcService {
   /// When the request is successful, an [RPCResponse] with the request id and
   /// the data from the server will be returned. If not, an RPCError will be
   /// thrown. Other errors might be thrown if an IO-Error occurs.
-  Future<RPCResponse> call(String function, [List<dynamic>? params]);
+  Future<RPCResponse> call(
+    String function, [
+    List<dynamic>? params,
+    Map<String, String>? additionalHeaders,
+  ]);
 }
 
 class JsonRPC extends RpcService {
@@ -33,7 +37,11 @@ class JsonRPC extends RpcService {
   /// the data from the server will be returned. If not, an RPCError will be
   /// thrown. Other errors might be thrown if an IO-Error occurs.
   @override
-  Future<RPCResponse> call(String function, [List<dynamic>? params]) async {
+  Future<RPCResponse> call(
+    String function, [
+    List<dynamic>? params,
+    Map<String, String>? additionalHeaders,
+  ]) async {
     params ??= [];
 
     final requestPayload = {
@@ -43,9 +51,15 @@ class JsonRPC extends RpcService {
       'id': _currentRequestId++,
     };
 
+    final headers = {'Content-Type': 'application/json'};
+
+    if (additionalHeaders != null) {
+      headers.addAll(additionalHeaders);
+    }
+
     final response = await client.post(
       Uri.parse(url),
-      headers: {'Content-Type': 'application/json'},
+      headers: headers,
       body: json.encode(requestPayload),
     );
 

--- a/lib/src/browser/dart_wrappers.dart
+++ b/lib/src/browser/dart_wrappers.dart
@@ -76,7 +76,7 @@ class _MetaMaskRpcService extends RpcService {
   _MetaMaskRpcService(this._ethereum);
 
   @override
-  Future<RPCResponse> call(String function, [List? params]) {
+  Future<RPCResponse> call(String function, [List? params, Map? _]) {
     return _ethereum.rawRequest(function, params: params).then((res) {
       return RPCResponse(0, res);
     });

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -25,17 +25,22 @@ class Web3Client {
   /// [httpClient] will be used to send requests to the rpc server.
   /// Am isolate will be used to perform expensive operations, such as signing
   /// transactions or computing private keys.
-  Web3Client(String url, Client httpClient, {this.socketConnector})
+  Web3Client(String url, Client httpClient,
+      {this.socketConnector, this.headers})
       : _jsonRpc = JsonRPC(url, httpClient) {
     _operations = _ExpensiveOperations();
     _filters = _FilterEngine(this);
   }
 
-  Web3Client.custom(RpcService rpc, {this.socketConnector}) : _jsonRpc = rpc;
+  Web3Client.custom(RpcService rpc, {this.socketConnector, this.headers})
+      : _jsonRpc = rpc;
 
   static const BlockNum _defaultBlock = BlockNum.current();
 
   final RpcService _jsonRpc;
+
+  // Optional headers to be passed for every request
+  final Map<String, String>? headers;
 
   /// Some ethereum nodes support an event channel over websockets. Web3dart
   /// will use the [StreamChannel] returned by this function as a socket to send
@@ -53,7 +58,7 @@ class Web3Client {
 
   Future<T> _makeRPCCall<T>(String function, [List<dynamic>? params]) async {
     try {
-      final data = await _jsonRpc.call(function, params);
+      final data = await _jsonRpc.call(function, params, headers);
       // ignore: only_throw_errors
       if (data is Error || data is Exception) throw data;
 


### PR DESCRIPTION
Hello, I am using getblock.io which recommends passing the API key in the requests headers. 

`'x-api-key: <YOUR-API-KEY>'`

I added an additional option to pass extra headers on the instantiation of `Web3Client` Let me know if you think there is a better way. 