### PR TITLE
uses an empty array to represent a null filter parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS-specific files
+.DS_Store
+
 # Files and directories created by pub
 .packages
 .pub/

--- a/lib/src/browser/credentials.dart
+++ b/lib/src/browser/credentials.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 import 'package:js/js.dart';
 import 'package:web3dart/web3dart.dart';
 
-import '../../credentials.dart';
 import '../../crypto.dart';
 
 import 'dart_wrappers.dart';

--- a/lib/src/contracts/generated_contract.dart
+++ b/lib/src/contracts/generated_contract.dart
@@ -2,7 +2,6 @@ import 'package:meta/meta.dart';
 
 import '../../crypto.dart';
 import '../../web3dart.dart';
-import 'deployed_contract.dart';
 
 /// Base classes for generated contracts.
 ///

--- a/lib/src/core/filters.dart
+++ b/lib/src/core/filters.dart
@@ -263,7 +263,9 @@ class _EventFilter extends _Filter<FilterEvent> {
       encodedOptions['address'] = options.address?.hex;
     }
     if (options.topics != null) {
-      encodedOptions['topics'] = options.topics;
+      final topics = <dynamic>[];
+      options.topics?.forEach((e) => topics.add(e.isEmpty ? null : e));
+      encodedOptions['topics'] = topics;
     }
 
     return encodedOptions;

--- a/test/core/event_filter_test.dart
+++ b/test/core/event_filter_test.dart
@@ -1,0 +1,130 @@
+import 'package:test/test.dart';
+import 'package:web3dart/web3dart.dart';
+
+import '../mock_client.dart';
+
+void main() {
+  const alice =
+      '0x000000000000000000000000Dd611f2b2CaF539aC9e12CF84C09CB9bf81CA37F';
+  const bob =
+      '0x0000000000000000000000006c87E1a114C3379BEc929f6356c5263d62542C13';
+  const contract = '0x16c5785ac562ff41e2dcfdf829c5a142f1fccd7d';
+
+  final testCases = [
+    {
+      'name': 'one topic',
+      'input': [
+        [alice]
+      ],
+      'expected': [
+        [alice]
+      ]
+    },
+    {
+      'name': 'two topics one item',
+      'input': [
+        [alice, bob]
+      ],
+      'expected': [
+        [alice, bob]
+      ]
+    },
+    {
+      'name': 'two topics two items',
+      'input': [
+        [alice],
+        [bob]
+      ],
+      'expected': [
+        [alice],
+        [bob]
+      ]
+    },
+    {
+      'name': 'two topics first null',
+      'input': [
+        [],
+        [bob]
+      ],
+      'expected': [
+        null,
+        [bob]
+      ]
+    },
+    {
+      'name': 'three topics first null',
+      'input': [
+        [],
+        [alice],
+        [bob]
+      ],
+      'expected': [
+        null,
+        [alice],
+        [bob]
+      ]
+    },
+    {
+      'name': 'three topics second null',
+      'input': [
+        [alice],
+        [],
+        [bob]
+      ],
+      'expected': [
+        [alice],
+        null,
+        [bob]
+      ]
+    }
+  ];
+
+  Future _runFilterTest(input, expected) async {
+    final client = MockClient(expectAsync2((method, params) {
+      expect(method, 'eth_getLogs');
+
+      // verify that the topics are sent to eth_getLogs in the correct format
+      final actual = ((params as List)[0])['topics'];
+      expect(actual, expected);
+
+      // return a valid response from eth_getLogs
+      return [
+        {'address': contract}
+      ];
+    }));
+
+    final web3 = Web3Client('', client);
+    addTearDown(web3.dispose);
+
+    // Dart typing will not allow an empty list to be added so when an empty
+    // list is encountered, a list containing a single string is added and then
+    // the single string in that list is removed.
+    // The type is required to ensure `topics` is forced to List<List<String>>
+
+    // ignore: omit_local_variable_types
+    final List<List<String>> topics = [];
+    input.forEach((element) {
+      if (element.length == 0) {
+        topics.add(['dummy string element']);
+        topics.last.remove('dummy string element');
+      } else {
+        topics.add(element as List<String>);
+      }
+    });
+
+    final filter = FilterOptions(
+        fromBlock: const BlockNum.genesis(),
+        toBlock: const BlockNum.current(),
+        address: EthereumAddress.fromHex(contract),
+        topics: topics);
+
+    await web3.getLogs(filter);
+  }
+
+  // test each test case in the list of test cases
+  for (final testCase in testCases) {
+    test('filters test with ${testCase['name']}', () async {
+      await _runFilterTest(testCase['input'], testCase['expected']);
+    });
+  }
+}

--- a/test/mock_client.dart
+++ b/test/mock_client.dart
@@ -12,6 +12,30 @@ class MockClient extends BaseClient {
   MockClient(this.handler);
 
   @override
+  Future<Response> post(Uri url,
+      {Map<String, String>? headers, Object? body, Encoding? encoding}) async {
+    if (body is! String) {
+      fail('Invalid request, expected string as request body');
+    }
+
+    final data = json.decode(body) as Map<String, dynamic>;
+    if (data['jsonrpc'] != '2.0') {
+      fail('Expected request to contain correct jsonrpc key');
+    }
+
+    final id = data['id'];
+    final method = data['method'] as String;
+    final params = data['params'];
+    final response = {
+      'body': body,
+      'id': id,
+      'result': handler(method, params)
+    };
+
+    return Response(json.encode(response), 200);
+  }
+
+  @override
   Future<StreamedResponse> send(BaseRequest request) async {
     final data = await _jsonUtf8.decoder.bind(request.finalize()).first;
 


### PR DESCRIPTION
Because `FilterOptions` defines `topics`
```dart
final List<List<String>>? topics;
```
there is no easy way to pass in `null` as a topic filter. This is not an issue if the "match all" topic is at the end of the list of topics; but, if the "match all" topic is not the last topic and `null` needs to be passed when creating a `FilterOptions` object there needs to be an explicit way of specifying "match all".

This change uses an empty array `[]` to represent `null` and does the translation between `[]` and `null` when `_createParamsObject` is called. Since a dynamic array is returned this allows the insertion of a `null` element in the array, something that is not possible when creating the `FilterOptions` object.

---

NOTE: This change limits the alterations to the existing code base. It may make better architectural sense to make a change to `FilterOptions` to allow topics in the array to be explicitly `null` (and potentially to be of type `String`) instead of each being an array of strings.
... and I may not have understood how to use filter correctly in the first place.