### PR TITLE
Change getValueInUnit from num to double

### DIFF
--- a/lib/src/core/amount.dart
+++ b/lib/src/core/amount.dart
@@ -72,7 +72,7 @@ class EtherAmount {
   /// especially for larger amounts or smaller units. While it can be used to
   /// display the amount of ether in a human-readable format, it should not be
   /// used for anything else.
-  num getValueInUnit(EtherUnit unit) {
+  double getValueInUnit(EtherUnit unit) {
     final factor = _factors[unit]!;
     final value = _value ~/ factor;
     final remainder = _value.remainder(factor);


### PR DESCRIPTION
The return value is always `double` and never any other `num` because this method has division:
`value.toInt() + (remainder.toInt() / factor.toInt());`

Division of two ints produces `double`, even if it is `1/1`. Then addition keeps it double.